### PR TITLE
1.5.1 新增是否开启apikey的负载均衡配置项

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -52,7 +52,7 @@ __plugin_meta__ = PluginMetadata(
     extra={
         "License": "BSD License",
         "Author": "颜曦",
-        "version": "1.5.0",
+        "version": "1.5.1",
     },
 )
 

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ from .custom_errors import ApiKeyError, NoApiKeyError
 
 class Config(BaseModel, extra=Extra.ignore):
     api_key: Union[str, List[str]] = None
+    key_load_balancing: bool = False
     history_save_path: Path = Path("data/ChatHistory").absolute()
     preset_path: Path = Path("data/Presets").absolute()
     openai_proxy: str = None

--- a/sessions.py
+++ b/sessions.py
@@ -184,9 +184,11 @@ class Session:
             logger.error(
                 f'当前不存在api key，请在配置文件里进行配置...')
             return ''
-        random.shuffle(api_keys)
+        if key_load_balancing:
+            random.shuffle(api_keys)
         for num, key in enumerate(api_keys):
             openai.api_key = key
+            logger.debug(f'当前使用 Api Key [{key[:4]}...{key[-4:]}]')
             try:
                 completion: dict = await openai.ChatCompletion.acreate(
                     model=model,
@@ -270,6 +272,7 @@ class Session:
 chat_memory_max = plugin_config.chat_memory_max if plugin_config.chat_memory_max > 2 else 2
 history_max = plugin_config.history_max if plugin_config.history_max > chat_memory_max else 100
 timeout = int(plugin_config.timeout) if plugin_config.timeout and plugin_config.timeout > 0 else 10
+key_load_balancing: bool = plugin_config.key_load_balancing
 
 session_container: SessionContainer = SessionContainer(
     dir_path=plugin_config.history_save_path,


### PR DESCRIPTION
**1.5.1**
**新增配置项：**
    `key_load_balancing` 是否开启apikey的负载均衡，默认为否

**其他修改：**
修改README中`"\"`与`"/"`混淆的错误，新增配置项相关内容
添加debug级别的log在调用apikey时显示当前使用的key

主要是听说一个ip不能同时调用多个key，虽然我自己试了感觉没什么问题，但也许我调用量比较小，频率也比较低，没触发openai的风控？
总之先做出个配置项给用户自己选择是否开启负载均衡，为了以防万一，默认设置为不开启
