### PR TITLE
1.6.1x 1.6.2√ 新增识别失效apikey指令，是否@sender，修改readme，修改文件加载bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,15 @@ api_key = '["sk-xxx...",
 的，所以算是必填项，正向代理使用 `openai_proxy`
 ，例如 `openai_proxy="127.0.0.1:1080"` （前提是你有代理，这只是个例子）
 
+`customize_prefix` 可以修改插件指令的公共前缀 默认是"/"，可以修改成别的，或者直接使用空字符串 `customize_prefix=""`
+则去掉这个前缀，**建议设置为空字符串或者别的**
+
 <details>
-  <summary><b style="font-size: 1.2rem">其他配置项详细介绍</b></summary>
+  <summary><b style="font-size: 1.2rem">部分非必填配置项介绍</b></summary>
+
+`allow_private` 是否允许私聊触发插件
+
+`at_sender` 回复是否@发送者
 
 `key_load_balancing` 选项可以选择是否开启apikey的负载均衡，可以简单理解为是否每次从所有key中随机选一个进行使用，默认为否（即一直使用同一个
 key 直到失效再切换下一个）<br>
@@ -99,14 +106,9 @@ ip 负载均衡或者自己做ip池（大概…<br>
 
 `preset_path` 是预设模板存放的文件夹，一般不需要改动
 
-`allow_private` 是否允许私聊触发插件
-
 `default_only_admin` 群组默认会话管理权限状态，默认为所有人均可创建管理会话<br>
 群组会话管理权限状态一共有两种：1、所有人均可以创建、管理会话；2、仅群主、管理员可以创建、管理会话，其余群员仅可加入对话<br>
 可以使用 `/chat auth on` 与 `/chat auth off` 指令切换会话管理状态，具体用法见下方指令介绍
-
-`customize_prefix` 可以修改插件指令的公共前缀 默认是"/"，可以修改成别的，或者直接使用空字符串 `customize_prefix=""`
-则去掉这个前缀
 
 `change_chat_to` 可以修改 `chat系` 指令 中的 "chat" 为自定义字符串，因为电脑版qq /chat xxx
 会被自动转换成表情，所以支持自定义。比如 `change_chat_to="Chat"` 就可以让 `/Chat list` 触发 `/chat list` 指令
@@ -120,22 +122,23 @@ ip 负载均衡或者自己做ip池（大概…<br>
 </details>
 <br>
 <details>
-  <summary><b style="font-size: 1.2rem">配置项表格</b></summary>
+  <summary><b style="font-size: 1.2rem">所有配置项表格</b></summary>
 
 |           配置项           | 必填 | 类型            |        默认值         |                                   说明                                    |
 |:-----------------------:|:--:|---------------|:------------------:|:-----------------------------------------------------------------------:|
 |         api_key         | 是  | str/List[str] |                    |      填入你的api_key,类似"sk-xxx..."，支持多个key，以字符串列表形式填入，某个key失效后会自动切换下一个      |
-|   key_load_balancing    | 否  | bool          |       False        |           是否启用apikey负载均衡，即每次使用不同的key访问，默认为关，即一直使用一个key直到失效再切换           |
+|      allow_private      | 否  | bool          |        true        |                              插件是否支持私聊，默认开启                              |
+|        at_sender        | 否  | bool          |        true        |                                回复是否@发送者                                 |                                 |
 |       model_name        | 否  | str           |  "gpt-3.5-turbo"   |                             模型名称，具体可参考官方文档                              |
-|       temperature       | 否  | float         |        0.5         | 设置使用gpt的理智值(temperature)，介于0~2之间，较高值如`0.8`会使会话更加随机，较低值如`0.2`会使会话更加集中和确定 |
 |      openai_proxy       | 否  | str           |        None        |                          正向HTTP代理 (HTTP PROXY)                          |
+|         timeout         | 否  | int           |         10         |                                 超时时间（秒）                                 |
 |     chat_memory_max     | 否  | int           |         10         |                          设置会话记忆上下文数量，填入大于2的数字                           |
 |       history_max       | 否  | int           |        100         |                        设置保存的最大历史聊天记录长度，填入大于2的数字                         |
 |    history_save_path    | 否  | str           | "data/ChatHistory" |                               设置会话记录保存路径                                |
 |     openai_api_base     | 否  | str           |        None        |                                  反向代理                                   |
-|         timeout         | 否  | int           |         10         |                                 超时时间（秒）                                 |
+|   key_load_balancing    | 否  | bool          |       false        |           是否启用apikey负载均衡，即每次使用不同的key访问，默认为关，即一直使用一个key直到失效再切换           |
+|       temperature       | 否  | float         |        0.5         | 设置使用gpt的理智值(temperature)，介于0~2之间，较高值如`0.8`会使会话更加随机，较低值如`0.2`会使会话更加集中和确定 |
 |       preset_path       | 否  | str           |   "data/Presets"   |                              填入自定义预设文件夹路径                               |
-|      allow_private      | 否  | bool          |        true        |                              插件是否支持私聊，默认开启                              |
 |   default_only_admin    | 否  | bool          |       false        |                       群组默认会话管理权限状态，默认为所有人均可创建管理会话                       |
 |     change_chat_to      | 否  | str           |        None        |           因为电脑端的qq在输入/chat xxx时候经常被转换成表情，所以支持自定义指令前缀替换"chat"            |
 |    customize_prefix     | 否  | str           |        "/"         |                   自定义命令前缀，不填默认为"/"，如果不想要前缀可以填入空字符串 ""                   |
@@ -150,6 +153,7 @@ ip 负载均衡或者自己做ip池（大概…<br>
 
 ```
 api_key=["sk-xxx...", "sk-yyy...", ...] # 最后一个key后面不要加逗号，另外如果要多行则列表前后加单引号，参考上方介绍
+at_sender=true
 key_load_balancing=false
 model_name="gpt-3.5-turbo" # 默认为gpt-3.5-turbo，具体可参考官方文档
 temperature=0.5 # 理智值，介于0~2之间
@@ -206,33 +210,35 @@ max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以�
 `/chat list <@user>` 获取当前群查看@的用户创建的会话<br>
 `/chat prompt` 查看当前会话的prompt<br>
 `/chat dump` 导出当前会话json字符串格式的上下文信息，可以用于`/chat json`导入<br>
+`/chat keys` 脱敏显示当前失效api key，仅主人
 
 <details>
   <summary><b style="font-size: 1.2rem">指令表格</b></summary>
 
-|           指令            |       权限        | 需要@ |  范围   |                    说明                     |
-|:-----------------------:|:---------------:|:---:|:-----:|:-----------------------------------------:|
-|      `/chat help`       |       群员        |  否  | 私聊/群聊 |                 获取指令帮助菜单                  |
-|      `/chat auth`       |       群员        |  否  |  群聊   |               获取当前群会话管理权限状态               |
-|     `/chat auth on`     |    主人/群主/管理员    |  否  |  群聊   |              设置当前群仅管理员可以管理会话              |
-|    `/chat auth off`     |    主人/群主/管理员    |  否  |  群聊   |              设置当前群所有人均可管理会话               |
-|     `/talk <会话内容>`      |       群员        |  否  | 私聊/群聊 |                在当前会话中进行会话                 |
-|       `/chat new`       |       群员        |  否  | 私聊/群聊 |          根据预制模板prompt创建并加入一个新的会话          |
-| `/chat new <自定义prompt>` |       群员        |  否  | 私聊/群聊 |          根据自定义prompt创建并加入一个新的会话           |
-|      `/chat json`       |       群员        |  否  | 私聊/群聊 | 根据历史会话json来创建一个会话，输入该命令后会提示你在下一个消息中输入json |
-|       `/chat cp`        |       群员        |  否  | 私聊/群聊 |             根据当前会话创建并加入一个新的会话             |
-|     `/chat cp <id>`     |       群员        |  否  | 私聊/群聊 | 根据会话<id>为模板进行复制新建加入（id为`/chat list`中的序号）  |
-|       `/chat del`       | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊 |                 删除当前所在会话                  |
-|    `/chat del <id>`     | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊 |     删除序号为<id>的会话（id为`/chat list`中的序号）     |
-|      `/chat clear`      |    主人/群主/管理员    |  否  | 私聊/群聊 |                 清空本群全部会话                  |
-|  `/chat clear <@user>`  | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊 |                删除@用户创建的会话                 |
-|    `/chat join <id>`    |       群员        |  否  | 私聊/群聊 |         加入会话（id为`/chat list`中的序号）         |
-|  `/chat rename <name>`  | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊 |                  重命名当前会话                  |
-|       `/chat who`       |       群员        |  否  | 私聊/群聊 |                 查看当前会话信息                  |
-|      `/chat list`       |       群员        |  否  | 私聊/群聊 |           获取当前群所有存在的会话的序号及创建时间            |
-|  `/chat list <@user>`   |       群员        |  否  |  群聊   |             获取当前群查看@的用户创建的会话              |
-|     `/chat prompt`      |       群员        |  否  | 私聊/群聊 |               查看当前会话的prompt               |
-|      `/chat dump`       |       群员        |  否  | 私聊/群聊 | 导出当前会话json字符串格式的上下文信息，可以用于`/chat json`导入  |
+|           指令            |       权限        | 需要@ |   范围   |                    说明                     |
+|:-----------------------:|:---------------:|:---:|:------:|:-----------------------------------------:|
+|      `/chat help`       |       群员        |  否  | 私聊/群聊  |                 获取指令帮助菜单                  |
+|      `/chat auth`       |       群员        |  否  |   群聊   |               获取当前群会话管理权限状态               |
+|     `/chat auth on`     |    主人/群主/管理员    |  否  |   群聊   |              设置当前群仅管理员可以管理会话              |
+|    `/chat auth off`     |    主人/群主/管理员    |  否  |   群聊   |              设置当前群所有人均可管理会话               |
+|     `/talk <会话内容>`      |       群员        |  否  | 私聊/群聊  |                在当前会话中进行会话                 |
+|       `/chat new`       |       群员        |  否  | 私聊/群聊  |          根据预制模板prompt创建并加入一个新的会话          |
+| `/chat new <自定义prompt>` |       群员        |  否  | 私聊/群聊  |          根据自定义prompt创建并加入一个新的会话           |
+|      `/chat json`       |       群员        |  否  | 私聊/群聊  | 根据历史会话json来创建一个会话，输入该命令后会提示你在下一个消息中输入json |
+|       `/chat cp`        |       群员        |  否  | 私聊/群聊  |             根据当前会话创建并加入一个新的会话             |
+|     `/chat cp <id>`     |       群员        |  否  | 私聊/群聊  | 根据会话<id>为模板进行复制新建加入（id为`/chat list`中的序号）  |
+|       `/chat del`       | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊  |                 删除当前所在会话                  |
+|    `/chat del <id>`     | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊  |     删除序号为<id>的会话（id为`/chat list`中的序号）     |
+|      `/chat clear`      |    主人/群主/管理员    |  否  | 私聊/群聊  |                 清空本群全部会话                  |
+|  `/chat clear <@user>`  | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊  |                删除@用户创建的会话                 |
+|    `/chat join <id>`    |       群员        |  否  | 私聊/群聊  |         加入会话（id为`/chat list`中的序号）         |
+|  `/chat rename <name>`  | 主人/群主/管理员/会话创建人 |  否  | 私聊/群聊  |                  重命名当前会话                  |
+|       `/chat who`       |       群员        |  否  | 私聊/群聊  |                 查看当前会话信息                  |
+|      `/chat list`       |       群员        |  否  | 私聊/群聊  |           获取当前群所有存在的会话的序号及创建时间            |
+|  `/chat list <@user>`   |       群员        |  否  |   群聊   |             获取当前群查看@的用户创建的会话              |
+|     `/chat prompt`      |       群员        |  否  | 私聊/群聊  |               查看当前会话的prompt               |
+|      `/chat dump`       |       群员        |  否  | 私聊/群聊  | 导出当前会话json字符串格式的上下文信息，可以用于`/chat json`导入  |
+|      `/chat keys`       |       主人        |  否  | 私聊 /群聊 |            脱敏显示当前失效api key，仅主人            |
 
 </details>
 
@@ -242,9 +248,12 @@ max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以�
   <summary><b style="font-size: 1.5rem">版本历史</b></summary>
 
 ### 1.6.1
+
 - 修改指令菜单显示不变BUG
 - 修改会话本地文件会加载权限文件的BUG
 - 新增APIKeyPool，减少使用失效API导致的时间浪费
+- 新增查看失效key指令：`/chat keys`
+- 新增配置项：`at_sender` 默认为true，回复会@发送者
 
 ### 1.6.0
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ api_key = '["sk-xxx...",
 的，所以算是必填项，正向代理使用 `openai_proxy`
 ，例如 `openai_proxy="127.0.0.1:1080"` （前提是你有代理，这只是个例子）
 
+<details>
+  <summary><b style="font-size: 1.2rem">其他配置项详细介绍</b></summary>
+
 `key_load_balancing` 选项可以选择是否开启apikey的负载均衡，可以简单理解为是否每次从所有key中随机选一个进行使用，默认为否（即一直使用同一个
 key 直到失效再切换下一个）<br>
 因为据说同一个 ip 不能同时调用多个apikey，尤其是短时间调用量很大的情况（不过个人没有测试过），所以默认为关闭负载均衡。如果想开启可能代理软件也需要多
@@ -114,28 +117,36 @@ ip 负载均衡或者自己做ip池（大概…<br>
 `auto_create_preset_info` 可以设置是否提示根据模板自动创建会话的信息，这条提示信息具体在用户不在任何会话时直接使用 `talk`
 指令时触发，如果嫌太过频繁可以关闭。但只能关闭掉自动创建提示，主动创建会话仍旧有提醒。
 
-|           配置项           | 必填  | 类型            |        默认值         |                                   说明                                    |
-|:-----------------------:|:---:|---------------|:------------------:|:-----------------------------------------------------------------------:|
-|         api_key         |  是  | str/List[str] |                    |      填入你的api_key,类似"sk-xxx..."，支持多个key，以字符串列表形式填入，某个key失效后会自动切换下一个      |
-|   key_load_balancing    |  否  | bool          |       False        |           是否启用apikey负载均衡，即每次使用不同的key访问，默认为关，即一直使用一个key直到失效再切换           |
-|       model_name        |  否  | str           |  "gpt-3.5-turbo"   |                             模型名称，具体可参考官方文档                              |
-|       temperature       |  否  | float         |        0.5         | 设置使用gpt的理智值(temperature)，介于0~2之间，较高值如`0.8`会使会话更加随机，较低值如`0.2`会使会话更加集中和确定 |
-|      openai_proxy       |  否  | str           |        None        |                          正向HTTP代理 (HTTP PROXY)                          |
-|     chat_memory_max     |  否  | int           |         10         |                          设置会话记忆上下文数量，填入大于2的数字                           |
-|       history_max       |  否  | int           |        100         |                        设置保存的最大历史聊天记录长度，填入大于2的数字                         |
-|    history_save_path    |  否  | str           | "data/ChatHistory" |                               设置会话记录保存路径                                |
-|     openai_api_base     |  否  | str           |        None        |                                  反向代理                                   |
-|         timeout         |  否  | int           |         10         |                                 超时时间（秒）                                 |
-|       preset_path       |  否  | str           |   "data/Presets"   |                              填入自定义预设文件夹路径                               |
-|      allow_private      |  否  | bool          |        true        |                              插件是否支持私聊，默认开启                              |
-|   default_only_admin    |  否  | bool          |       false        |                       群组默认会话管理权限状态，默认为所有人均可创建管理会话                       |
-|     change_chat_to      |  否  | str           |        None        |           因为电脑端的qq在输入/chat xxx时候经常被转换成表情，所以支持自定义指令前缀替换"chat"            |
-|    customize_prefix     |  否  | str           |        "/"         |                   自定义命令前缀，不填默认为"/"，如果不想要前缀可以填入空字符串 ""                   |
-|   customize_talk_cmd    |  否  | str           |       "talk"       |              自定义和GPT会话的命令后缀，为了防止在去除前缀情况下talk因为常见而误触发可以自定义               |
-| auto_create_preset_info |  否  | bool          |        true        |          是否发送自动根据模板创建会话的信息，如果嫌烦可以关掉，不过只能关掉自动创建的提示，主动创建的会一直有提醒           |
-|       max_tokens        |  否  | int           |        1024        |                              一次最大回复token数量                              |
+</details>
+<br>
+<details>
+  <summary><b style="font-size: 1.2rem">配置项表格</b></summary>
 
-格式如下:
+|           配置项           | 必填 | 类型            |        默认值         |                                   说明                                    |
+|:-----------------------:|:--:|---------------|:------------------:|:-----------------------------------------------------------------------:|
+|         api_key         | 是  | str/List[str] |                    |      填入你的api_key,类似"sk-xxx..."，支持多个key，以字符串列表形式填入，某个key失效后会自动切换下一个      |
+|   key_load_balancing    | 否  | bool          |       False        |           是否启用apikey负载均衡，即每次使用不同的key访问，默认为关，即一直使用一个key直到失效再切换           |
+|       model_name        | 否  | str           |  "gpt-3.5-turbo"   |                             模型名称，具体可参考官方文档                              |
+|       temperature       | 否  | float         |        0.5         | 设置使用gpt的理智值(temperature)，介于0~2之间，较高值如`0.8`会使会话更加随机，较低值如`0.2`会使会话更加集中和确定 |
+|      openai_proxy       | 否  | str           |        None        |                          正向HTTP代理 (HTTP PROXY)                          |
+|     chat_memory_max     | 否  | int           |         10         |                          设置会话记忆上下文数量，填入大于2的数字                           |
+|       history_max       | 否  | int           |        100         |                        设置保存的最大历史聊天记录长度，填入大于2的数字                         |
+|    history_save_path    | 否  | str           | "data/ChatHistory" |                               设置会话记录保存路径                                |
+|     openai_api_base     | 否  | str           |        None        |                                  反向代理                                   |
+|         timeout         | 否  | int           |         10         |                                 超时时间（秒）                                 |
+|       preset_path       | 否  | str           |   "data/Presets"   |                              填入自定义预设文件夹路径                               |
+|      allow_private      | 否  | bool          |        true        |                              插件是否支持私聊，默认开启                              |
+|   default_only_admin    | 否  | bool          |       false        |                       群组默认会话管理权限状态，默认为所有人均可创建管理会话                       |
+|     change_chat_to      | 否  | str           |        None        |           因为电脑端的qq在输入/chat xxx时候经常被转换成表情，所以支持自定义指令前缀替换"chat"            |
+|    customize_prefix     | 否  | str           |        "/"         |                   自定义命令前缀，不填默认为"/"，如果不想要前缀可以填入空字符串 ""                   |
+|   customize_talk_cmd    | 否  | str           |       "talk"       |              自定义和GPT会话的命令后缀，为了防止在去除前缀情况下talk因为常见而误触发可以自定义               |
+| auto_create_preset_info | 否  | bool          |        true        |          是否发送自动根据模板创建会话的信息，如果嫌烦可以关掉，不过只能关掉自动创建的提示，主动创建的会一直有提醒           |
+|       max_tokens        | 否  | int           |        1024        |                              一次最大回复token数量                              |
+
+</details>
+<br>
+<details>
+  <summary><b style="font-size: 1.2rem">配置项示例</b></summary>
 
 ```
 api_key=["sk-xxx...", "sk-yyy...", ...] # 最后一个key后面不要加逗号，另外如果要多行则列表前后加单引号，参考上方介绍
@@ -158,7 +169,9 @@ auto_create_preset_info=false # 具体效果见上方介绍，如果不需要修
 max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以直接删掉这一行
 ```
 
-## 基础命令
+</details>
+
+## 基础指令
 
 `/chat help` 获取指令帮助菜单<br>
 `/chat auth` 获取当前群会话管理权限状态<br>
@@ -194,6 +207,9 @@ max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以�
 `/chat prompt` 查看当前会话的prompt<br>
 `/chat dump` 导出当前会话json字符串格式的上下文信息，可以用于`/chat json`导入<br>
 
+<details>
+  <summary><b style="font-size: 1.2rem">指令表格</b></summary>
+
 |           指令            |       权限        | 需要@ |  范围   |                    说明                     |
 |:-----------------------:|:---------------:|:---:|:-----:|:-----------------------------------------:|
 |      `/chat help`       |       群员        |  否  | 私聊/群聊 |                 获取指令帮助菜单                  |
@@ -218,7 +234,17 @@ max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以�
 |     `/chat prompt`      |       群员        |  否  | 私聊/群聊 |               查看当前会话的prompt               |
 |      `/chat dump`       |       群员        |  否  | 私聊/群聊 | 导出当前会话json字符串格式的上下文信息，可以用于`/chat json`导入  |
 
-## 版本历史
+</details>
+
+<br>
+
+<details>
+  <summary><b style="font-size: 1.5rem">版本历史</b></summary>
+
+### 1.6.1
+- 修改指令菜单显示不变BUG
+- 修改会话本地文件会加载权限文件的BUG
+- 新增APIKeyPool，减少使用失效API导致的时间浪费
 
 ### 1.6.0
 
@@ -227,7 +253,12 @@ max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以�
 - 新增管理会话权限相关指令：`/chat auth`、`/chat auth on` 、`/chat auth off`
 - 新增管理会话权限相关配置项：`default_only_admin` 群组默认会话管理权限状态，默认为所有人均可创建管理会话
 
-## 使用效果预览(已过时)
+</details>
+
+<br>
+
+<details>
+  <summary><b style="font-size: 1.5rem">使用效果预览(已过时)</b></summary>
 
 ### 利用模板创建新的会话
 
@@ -257,3 +288,4 @@ max_tokens=1024 # 具体效果见上方介绍，如果不需要修改也可以�
 
 ![image](https://user-images.githubusercontent.com/33772816/223603594-126b4b7a-4184-4129-bd72-fce62a90da8e.png)
 
+</details>

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
-import json
 import re
+import json
 from datetime import datetime
 from json import JSONDecodeError
 from typing import Dict, List, Any, Type
@@ -29,7 +29,7 @@ prefix_str = customize_prefix if customize_prefix is not None else '/'
 chat_str = f'(chat|{change_chat_to})' if change_chat_to else 'chat'
 talk_cmd_str = customize_talk_cmd if customize_talk_cmd else 'talk'
 pattern_str = prefix_str + chat_str
-menu_chat_str=prefix_str+f'{change_chat_to}' if change_chat_to else 'chat'
+menu_chat_str = prefix_str + f'{change_chat_to}' if change_chat_to else 'chat'
 
 __usage__: str = (
     "指令表：\n"
@@ -58,6 +58,7 @@ __usage__: str = (
     f"    {menu_chat_str} list <@user> 获取当前群查看@的用户创建的会话\n"
     f"    {menu_chat_str} prompt 查看当前会话的prompt\n"
     f"    {menu_chat_str} dump 导出当前会话json字符串格式的上下文信息，可以用于{menu_chat_str} json导入\n"
+    f"    {menu_chat_str} keys 脱敏显示当前失效api key，仅主人"
 
 )
 __plugin_meta__ = PluginMetadata(
@@ -78,8 +79,7 @@ temperature: float = plugin_config.temperature
 model: str = plugin_config.model_name
 max_tokens: int = plugin_config.max_tokens
 auto_create_preset_info: bool = plugin_config.auto_create_preset_info
-
-
+at_sender: bool = plugin_config.at_sender
 
 
 async def _allow_private_checker(event: MessageEvent) -> bool:
@@ -110,21 +110,27 @@ ChatClearAt = on_regex(rf"{pattern_str}\s+clear\s*\S+$", permission=ALLOW_PRIVAT
 SetAuthOn = on_regex(rf'^{pattern_str}\s+auth on$', permission=GROUP)
 SetAuthOff = on_regex(rf'^{pattern_str}\s+auth off$', permission=GROUP)
 ShowAuth = on_regex(rf'^{pattern_str}\s+auth$', permission=GROUP)
+ShowFailKey = on_regex(rf'^{pattern_str}\s+keys$', permission=SUPERUSER)
+
+
+@ShowFailKey.handle()
+async def _(event: MessageEvent):
+    await ShowFailKey.finish(api_keys.show_fail_keys(), at_sender=True)
 
 
 @ShowAuth.handle()
 async def _(event: GroupMessageEvent):
     group_id: str = get_group_id(event)
     if session_container.get_group_auth(group_id):
-        await ShowAuth.finish("当前仅有管理员有权限管理会话")
-    await ShowAuth.finish("当前所有人均有权限管理会话")
+        await ShowAuth.finish("当前仅有管理员有权限管理会话", at_sender=True)
+    await ShowAuth.finish("当前所有人均有权限管理会话", at_sender=True)
 
 
 async def auth_check(matcher: Type[Matcher], bot: Bot, event: MessageEvent, group_id: str) -> None:
     if isinstance(event, PrivateMessageEvent):
         return
     if session_container.get_group_auth(group_id) and not (await admin_check(bot, event)):
-        await matcher.finish('该群仅有管理员可以管理会话')
+        await matcher.finish('该群仅有管理员可以管理会话', at_sender=True)
 
 
 async def admin_check(bot: Bot, event: MessageEvent) -> bool:
@@ -138,9 +144,9 @@ async def _(bot: Bot, event: GroupMessageEvent):
     group_id: str = get_group_id(event)
     perm_check = await admin_check(bot, event)
     if not perm_check:
-        await SetAuthOff.finish("只有群主或管理员才能设置权限管理")
+        await SetAuthOff.finish("只有群主或管理员才能设置权限管理", at_sender=True)
     session_container.set_group_auth(group_id, False)
-    await SetAuthOff.finish("设置成功，当前所有人均有权限管理会话")
+    await SetAuthOff.finish("设置成功，当前所有人均有权限管理会话", at_sender=True)
 
 
 @SetAuthOn.handle()
@@ -148,9 +154,9 @@ async def _(bot: Bot, event: GroupMessageEvent):
     group_id: str = get_group_id(event)
     perm_check = await admin_check(bot, event)
     if not perm_check:
-        await SetAuthOn.finish("只有群主或管理员才能设置权限管理")
+        await SetAuthOn.finish("只有群主或管理员才能设置权限管理", at_sender=True)
     session_container.set_group_auth(group_id, True)
-    await SetAuthOn.finish("设置成功，当前仅有管理员有权限管理会话")
+    await SetAuthOn.finish("设置成功，当前仅有管理员有权限管理会话", at_sender=True)
 
 
 @ChatClear.handle()
@@ -158,12 +164,12 @@ async def _(bot: Bot, event: MessageEvent):
     group_id: str = get_group_id(event)
     perm_check = await admin_check(bot, event)
     if not perm_check:
-        await ChatClear.finish("只有群主或管理员才能清空本群全部会话!")
+        await ChatClear.finish("只有群主或管理员才能清空本群全部会话!", at_sender=True)
     session_list: List[Session] = session_container.get_group_sessions(group_id)
     num = len(session_list)
     for session in session_list:
         await session_container.delete_session(session, group_id)
-    await ChatClear.finish(f"成功删除全部共{num}条会话")
+    await ChatClear.finish(f"成功删除全部共{num}条会话", at_sender=True)
 
 
 @ChatClearAt.handle()
@@ -178,14 +184,15 @@ async def _(bot: Bot, event: MessageEvent, message: Message = EventMessage()):
     user_id: int = int(segments[0].data.get("qq", ""))
     group_id: str = get_group_id(event)
     if user_id != sender_id and not perm_check:
-        await ChatClearAt.finish("您不是该会话的创建者或管理员!")
-    session_list: List[Session] = [s for s in session_container.sessions if s.group == group_id and s.creator == user_id]
+        await ChatClearAt.finish("您不是该会话的创建者或管理员!", at_sender=True)
+    session_list: List[Session] = [s for s in session_container.sessions if
+                                   s.group == group_id and s.creator == user_id]
     num = len(session_list)
     if num == 0:
-        await ChatClearAt.finish(f"本群用户 {user_id} 还没有创建过会话哦")
+        await ChatClearAt.finish(f"本群用户 {user_id} 还没有创建过会话哦", at_sender=True)
     for session in session_list:
         await session_container.delete_session(session, group_id)
-    await ChatClearAt.finish(f"成功删除本群用户 {user_id} 创建的全部会话共{num}条")
+    await ChatClearAt.finish(f"成功删除本群用户 {user_id} 创建的全部会话共{num}条", at_sender=True)
 
 
 @ChatCP.handle()
@@ -195,7 +202,8 @@ async def _(bot: Bot, event: MessageEvent):
     await auth_check(ChatCP, bot, event, group_id)
     group_usage: Dict[int, Session] = session_container.get_group_usage(group_id)
     if user_id not in group_usage:
-        await ChatCP.finish(f'请先加入一个会话，再进行复制当前会话 或者使用 {menu_chat_str} cp <id> 进行复制')
+        await ChatCP.finish(f'请先加入一个会话，再进行复制当前会话 或者使用 {menu_chat_str} cp <id> 进行复制',
+                            at_sender=True)
     session: Session = group_usage[user_id]
     group_usage[user_id].del_user(user_id)
     new_session: Session = session_container.create_with_session(session, user_id, group_id)
@@ -208,9 +216,9 @@ async def _(event: MessageEvent):
     group_id: str = get_group_id(event)
     group_usage: Dict[int, Session] = session_container.get_group_usage(group_id)
     if user_id not in group_usage:
-        await ChatPrompt.finish('请先加入一个会话，再进行重命名')
+        await ChatPrompt.finish('请先加入一个会话，再进行重命名', at_sender=True)
     session: Session = group_usage[user_id]
-    await ChatPrompt.finish(f'会话：{session.name}\nprompt：{session.prompt}')
+    await ChatPrompt.finish(f'会话：{session.name}\nprompt：{session.prompt}', at_sender=True)
 
 
 @ReName.handle()
@@ -220,15 +228,15 @@ async def _(bot: Bot, event: MessageEvent, info: Dict[str, Any] = RegexDict()):
     await auth_check(ReName, bot, event, group_id)
     group_usage: Dict[int, Session] = session_container.get_group_usage(group_id)
     if user_id not in group_usage:
-        await ReName.finish('请先加入一个会话，再进行重命名')
+        await ReName.finish('请先加入一个会话，再进行重命名', at_sender=True)
     perm_check = await admin_check(bot, event)
     session: Session = group_usage[user_id]
     name: str = unescape(info.get('name', '').strip())
     if session.creator == user_id or perm_check:
         session.rename(name[:32])
-        await ReName.finish(f'当前会话已命名为 {session.name}')
-    logger.info(f'重命名群 {group_id} 会话 {session.name} 失败：权限不足')
-    await ReName.finish("您不是该会话的创建者或管理员!")
+        await ReName.finish(f'当前会话已命名为 {session.name}', at_sender=True)
+    logger.info(f'重命名群 {group_id} 会话 {session.name} 失败：权限不足', at_sender=True)
+    await ReName.finish("您不是该会话的创建者或管理员!", at_sender=True)
 
 
 @ChatUserList.handle()
@@ -240,13 +248,14 @@ async def _(event: MessageEvent, message: Message = EventMessage()):
         await ChatUserList.finish()
     user_id: int = int(segments[0].data.get("qq", ""))
     group_id: str = get_group_id(event)
-    session_list: List[Session] = [s for s in session_container.sessions if s.group == group_id and s.creator == user_id]
+    session_list: List[Session] = [s for s in session_container.sessions if
+                                   s.group == group_id and s.creator == user_id]
     msg: str = f"在群中创建会话{len(session_list)}条：\n"
     for index, session in enumerate(session_list):
         msg += f" 名称:{session.name[:10]} " \
                f"创建者:{session.creator} " \
                f"时间:{datetime.fromtimestamp(session.creation_time)}\n"
-    await ChatUserList.finish(MessageSegment.at(user_id) + msg)
+    await ChatUserList.finish(MessageSegment.at(user_id) + msg, at_sender=True)
 
 
 @ChatWho.handle()
@@ -255,14 +264,14 @@ async def _(event: MessageEvent):
     group_id: str = get_group_id(event)
     group_usage: Dict[int, Session] = session_container.get_group_usage(group_id)
     if user_id not in group_usage:
-        await ChatWho.finish('当前没有加入任何会话，请加入或创建一个会话')
+        await ChatWho.finish('当前没有加入任何会话，请加入或创建一个会话', at_sender=True)
     session: Session = group_usage[user_id]
     msg = f'当前所在会话信息:\n' \
           f"名称:{session.name[:10]}\n" \
           f"创建者:{session.creator}\n" \
           f"时间:{datetime.fromtimestamp(session.creation_time)}\n" \
           f"可以使用 {menu_chat_str} dump 导出json字符串格式的上下文信息"
-    await ChatWho.finish(msg)
+    await ChatWho.finish(msg, at_sender=True)
 
 
 @ChatCopy.handle()
@@ -290,9 +299,9 @@ async def _(event: MessageEvent):
     group_id: str = get_group_id(event)
     try:
         session: Session = session_container.get_user_usage(group_id, user_id)
-        await Dump.finish(session.dump2json_str())
+        await Dump.finish(session.dump2json_str(), at_sender=True)
     except NeedCreatSession:
-        await Dump.finish('请先加入一个会话')
+        await Dump.finish('请先加入一个会话', at_sender=True)
 
 
 @Chat.handle()
@@ -311,9 +320,7 @@ async def _(event: MessageEvent, info: Dict[str, Any] = RegexDict()):
     else:
         session: Session = group_usage[user_id]
     answer: str = await session.ask_with_content(api_keys, content, 'user', temperature, model, max_tokens)
-    if answer:
-        await Chat.finish(answer)
-    await Chat.finish('连接失败...报错信息请查看日志')
+    await Chat.finish(answer, at_sender=at_sender)
 
 
 @Join.handle()
@@ -349,13 +356,13 @@ async def _(bot: Bot, event: MessageEvent):
     group_usage: Dict[int, Session] = session_container.get_group_usage(group_id)
     session: Session = group_usage.pop(user_id, None)
     if not session:
-        await DelSelf.finish("当前不存在会话")
+        await DelSelf.finish("当前不存在会话", at_sender=True)
     perm_check = await admin_check(bot, event)
     if session.creator == user_id or perm_check:
         await session_container.delete_session(session, group_id)
-        await DelSelf.finish("删除成功!")
-    logger.info(f'删除群 {group_id} 会话 {session.name} 失败：权限不足')
-    await DelSelf.finish("您不是该会话的创建者或管理员!")
+        await DelSelf.finish("删除成功!", at_sender=True)
+    logger.info(f'删除群 {group_id} 会话 {session.name} 失败：权限不足', at_sender=True)
+    await DelSelf.finish("您不是该会话的创建者或管理员!", at_sender=True)
 
 
 @Delete.handle()
@@ -366,17 +373,17 @@ async def _(bot: Bot, event: MessageEvent, info: Dict[str, Any] = RegexDict()):
     await auth_check(Delete, bot, event, group_id)
     group_sessions: List[Session] = session_container.get_group_sessions(group_id)
     if not group_sessions:
-        await Delete.finish("当前不存在会话")
+        await Delete.finish("当前不存在会话", at_sender=True)
     if session_id < 1 or session_id > len(group_sessions):
         await Delete.finish("序号超出!", at_sender=True)
     session: Session = group_sessions[session_id - 1]
     perm_check = await admin_check(bot, event)
     if session.creator == user_id or perm_check:
         await session_container.delete_session(session, group_id)
-        await Delete.finish("删除成功!")
+        await Delete.finish("删除成功!", at_sender=True)
     else:
-        logger.info(f'删除群 {group_id} 会话 {session.name} 失败：权限不足')
-        await Delete.finish("您不是该会话的创建者或管理员!")
+        logger.info(f'删除群 {group_id} 会话 {session.name} 失败：权限不足', at_sender=True)
+        await Delete.finish("您不是该会话的创建者或管理员!", at_sender=True)
 
 
 # 暂时已完成
@@ -422,7 +429,7 @@ async def Create(event: MessageEvent, template_id: str = ArgPlainText("template"
     user_id: int = int(event.get_user_id())
     group_id: str = get_group_id(event)
     if not template_id.isdigit():
-        await CreateConversationWithTemplate.finish("输入ID无效！")
+        await CreateConversationWithTemplate.finish("输入ID无效！", at_sender=True)
     session: Session = session_container.create_with_template(template_id, user_id, group_id)
     await CreateConversationWithTemplate.send(f"使用模板 '{template_id}' 创建并加入会话 '{session.name}' 成功!",
                                               at_sender=True)
@@ -441,9 +448,9 @@ async def GetJson(event: MessageEvent, json_str: str = ArgPlainText("jsonStr")):
         chat_log = json.loads(json_str)
     except JSONDecodeError:
         logger.error("json字符串错误!")
-        await CreateConversationWithJson.finish("Json错误！")
+        await CreateConversationWithJson.finish("Json错误！", at_sender=True)
     if not chat_log[0].get("role"):
-        await CreateConversationWithJson.finish("Json错误！")
+        await CreateConversationWithJson.finish("Json错误！", at_sender=True)
     user_id: int = int(event.get_user_id())
     group_id: str = get_group_id(event)
     session: Session = session_container.create_with_chat_log(chat_log, user_id, group_id,

--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@ from nonebot.params import ArgPlainText, RegexDict, EventMessage
 from nonebot.permission import SUPERUSER, Permission
 from nonebot.plugin import PluginMetadata
 
-from .config import Config, plugin_config
+from .config import Config, plugin_config, APIKeyPool
 from .loadpresets import presets_str
 from .custom_errors import NeedCreatSession
 from .sessions import session_container, Session, get_group_id
@@ -37,7 +37,7 @@ __usage__: str = (
     f"    {menu_chat_str} auth 获取当前群会话管理权限状态\n"
     f"    {menu_chat_str} auth on 设置当前群仅管理员可以管理会话\n"
     f"    {menu_chat_str} auth off 设置当前群所有人均可管理会话\n"
-    f"    /talk <会话内容> 在当前会话中进行会话(同样不需要括号，后面直接接你要说的话就行)\n"
+    f"    {prefix_str}{talk_cmd_str} <会话内容> 在当前会话中进行会话(同样不需要括号，后面直接接你要说的话就行)\n"
     ">> 增\n"
     f"    {menu_chat_str} new  根据预制模板prompt创建并加入一个新的会话\n"
     f"    {menu_chat_str} new <自定义prompt> 根据自定义prompt创建并加入一个新的会话\n"
@@ -68,12 +68,12 @@ __plugin_meta__ = PluginMetadata(
     extra={
         "License": "BSD License",
         "Author": "颜曦",
-        "version": "1.6.0",
+        "version": "1.6.1",
     },
 )
 
 allow_private: bool = plugin_config.allow_private
-api_keys: List[str] = session_container.api_keys
+api_keys: APIKeyPool = session_container.api_keys
 temperature: float = plugin_config.temperature
 model: str = plugin_config.model_name
 max_tokens: int = plugin_config.max_tokens

--- a/apikey.py
+++ b/apikey.py
@@ -1,0 +1,61 @@
+import random
+from typing import List, Union
+from collections import UserString, UserList
+
+
+class APIKey(UserString):
+    def __init__(self, key: str):
+        super().__init__(key.strip())
+        self.status: bool = True
+        self.fail_res: str = ''
+
+    @property
+    def key(self) -> str:
+        return self.data
+
+    def show(self) -> str:
+        return f'[{self.data[:8]}....{self.data[-4:]}]'
+
+    def fail(self, fail_res: str):
+        self.status = False
+        self.fail_res = fail_res
+
+    def show_fail(self) -> str:
+        return f'{self.show()} {self.fail_res}'
+
+
+class APIKeyPool(UserList):
+
+    def __init__(self, api_keys: Union[str, list]):
+        if not api_keys or not (isinstance(api_keys, list) or isinstance(api_keys, str)):
+            raise Exception('请输入正确的APIKEY')
+        if isinstance(api_keys, str):
+            api_keys = [api_keys]
+        self.valid_num: int = len(api_keys)
+        super().__init__([APIKey(k) for k in api_keys])
+
+    @property
+    def api_keys(self) -> List[APIKey]:
+        return self.data
+
+    def __len__(self):
+        return len(self.api_keys)
+
+    @property
+    def len(self) -> int:
+        return len(self.api_keys)
+
+    def shuffle(self):
+        random.shuffle(self.api_keys)
+
+    def fail_keys(self) -> List[APIKey]:
+        return [k for k in self.api_keys if not k.status]
+
+    def show_fail_keys(self) -> str:
+        msg = f'当前存在apikey共{len(self.api_keys)}个\n'
+        fail_num = len(self.fail_keys())
+        self.valid_num = len(self.api_keys) - fail_num
+        msg += f'已失效key共{fail_num}个：\n'
+        for k in self.fail_keys():
+            msg += f'{k.show_fail()}\n'
+        return msg.strip()

--- a/config.py
+++ b/config.py
@@ -1,78 +1,10 @@
-import random
 from pathlib import Path
 from typing import List, Union
-from collections import deque, UserString
 
 from nonebot import get_driver
 from pydantic import Extra, BaseModel, validator
 
-
-class APIKey(UserString):
-    def __init__(self, key: str):
-        super().__init__(key.strip())
-        self.fail_num: int = 0
-
-    @property
-    def key(self) -> str:
-        return self.data
-
-    def fail(self):
-        self.fail_num += 1
-
-    def reset(self):
-        self.fail_num = 0
-
-    def __str__(self):
-        return f'key:{self.data},num:{self.fail_num}'
-
-
-class APIKeyPool:
-    api_keys: deque[APIKey] = deque()
-    is_shuffle: bool = False
-
-    def __init__(self, api_keys: Union[str, list]):
-        if not api_keys or not (isinstance(api_keys, list) or isinstance(api_keys, str)):
-            raise Exception('请输入正确的APIKEY')
-        if isinstance(api_keys, str):
-            api_keys = [api_keys]
-        for key in api_keys:
-            self.api_keys.append(APIKey(key))
-        self.len = len(api_keys)
-
-    def __len__(self):
-        return self.len
-
-    def shuffle(self):
-        self.is_shuffle = True
-        random.shuffle(self.api_keys)
-
-    def get_key(self) -> str:
-        return self.api_keys[0].key
-
-    def fail(self):
-        if self.is_shuffle:
-            self.api_keys.append(self.api_keys.popleft())
-            return
-        self.api_keys[0].fail()
-        if self.api_keys[0].fail_num > 2:
-            self.api_keys[0].reset()
-        self.api_keys.append(self.api_keys.popleft())
-
-    def success(self):
-        if self.is_shuffle:
-            return
-        self.api_keys[0].reset()
-
-    def refresh(self):
-        if self.is_shuffle:
-            return
-        for i in range(self.len):
-            if self.api_keys[-1].fail_num == 0:
-                break
-            if self.api_keys[-1].fail_num < 3:
-                self.api_keys.appendleft(self.api_keys.pop())
-            else:
-                self.api_keys[-1].reset()
+from .apikey import APIKeyPool
 
 
 class Config(BaseModel, extra=Extra.ignore, arbitrary_types_allowed=True):
@@ -94,6 +26,7 @@ class Config(BaseModel, extra=Extra.ignore, arbitrary_types_allowed=True):
     customize_talk_cmd: str = 'talk'
     timeout: int = 10
     default_only_admin: bool = False
+    at_sender: bool = True
 
     @validator('api_key')
     def api_key_validator(cls, v) -> APIKeyPool:

--- a/config.py
+++ b/config.py
@@ -1,14 +1,82 @@
+import random
 from pathlib import Path
 from typing import List, Union
+from collections import deque, UserString
 
 from nonebot import get_driver
 from pydantic import Extra, BaseModel, validator
 
-from .custom_errors import ApiKeyError, NoApiKeyError
+
+class APIKey(UserString):
+    def __init__(self, key: str):
+        super().__init__(key.strip())
+        self.fail_num: int = 0
+
+    @property
+    def key(self) -> str:
+        return self.data
+
+    def fail(self):
+        self.fail_num += 1
+
+    def reset(self):
+        self.fail_num = 0
+
+    def __str__(self):
+        return f'key:{self.data},num:{self.fail_num}'
 
 
-class Config(BaseModel, extra=Extra.ignore):
-    api_key: Union[str, List[str]] = None
+class APIKeyPool:
+    api_keys: deque[APIKey] = deque()
+    is_shuffle: bool = False
+
+    def __init__(self, api_keys: Union[str, list]):
+        if not api_keys or not (isinstance(api_keys, list) or isinstance(api_keys, str)):
+            raise Exception('请输入正确的APIKEY')
+        if isinstance(api_keys, str):
+            api_keys = [api_keys]
+        for key in api_keys:
+            self.api_keys.append(APIKey(key))
+        self.len = len(api_keys)
+
+    def __len__(self):
+        return self.len
+
+    def shuffle(self):
+        self.is_shuffle = True
+        random.shuffle(self.api_keys)
+
+    def get_key(self) -> str:
+        return self.api_keys[0].key
+
+    def fail(self):
+        if self.is_shuffle:
+            self.api_keys.append(self.api_keys.popleft())
+            return
+        self.api_keys[0].fail()
+        if self.api_keys[0].fail_num > 2:
+            self.api_keys[0].reset()
+        self.api_keys.append(self.api_keys.popleft())
+
+    def success(self):
+        if self.is_shuffle:
+            return
+        self.api_keys[0].reset()
+
+    def refresh(self):
+        if self.is_shuffle:
+            return
+        for i in range(self.len):
+            if self.api_keys[-1].fail_num == 0:
+                break
+            if self.api_keys[-1].fail_num < 3:
+                self.api_keys.appendleft(self.api_keys.pop())
+            else:
+                self.api_keys[-1].reset()
+
+
+class Config(BaseModel, extra=Extra.ignore, arbitrary_types_allowed=True):
+    api_key: Union["APIKeyPool", str, List[str]] = None
     key_load_balancing: bool = False
     history_save_path: Path = Path("data/ChatHistory").absolute()
     preset_path: Path = Path("data/Presets").absolute()
@@ -28,14 +96,8 @@ class Config(BaseModel, extra=Extra.ignore):
     default_only_admin: bool = False
 
     @validator('api_key')
-    def api_key_validator(cls, v) -> List[str]:
-        if not v:
-            raise NoApiKeyError('请输入APIKEY')
-        if isinstance(v, list):
-            return v
-        if isinstance(v, str):
-            return [v]
-        raise ApiKeyError('请输入正确的APIKEY')
+    def api_key_validator(cls, v) -> APIKeyPool:
+        return APIKeyPool(v)
 
 
 plugin_config: Config = Config.parse_obj(get_driver().config)

--- a/sessions.py
+++ b/sessions.py
@@ -92,7 +92,12 @@ class SessionContainer:
             session.save()
 
     def load(self) -> None:
-        for file in list(self.dir_path.glob('*.json')):
+        files: List[Path] = list(self.dir_path.glob('*.json'))
+        try:
+            files.remove(self.group_auth_file_path)
+        except ValueError:
+            pass
+        for file in files:
             session = Session.reload_from_file(file)
             if not session:
                 continue


### PR DESCRIPTION
~~**1.6.1**~~ -- **1.6.2** （提交的时候没注意pypi上的版本，需要改下__init__和ReadMe文件里的版本信息
**新增APIKeyPool：**
加入APIKeyPool，根据openai的error类型InvalidAPIType, AuthenticationError, PermissionError, RateLimitError
识别并标记出已失效的key，请求时跳过失效key，防止使用失效key请求占用时间
**新增指令：**
    `/chat keys` 仅允许主人，脱敏显示当前识别到的失效api key
**新增配置项：**
    `at_sender` 对话回复是否@发送者，默认True
**其他修改：**
在加载本地会话文件时错误加载的权限文件(group_auth_file.json)进行排除
优化README的内容，之前感觉README过长，增加了折叠内容。（不过我感觉我选择的折叠的内容其实效果也不是很好，还有很多优化空间...
之前的菜单内容还有talk的没有修改，已经补充修改
**对用户影响：**
原本默认对话回复不@发送者，如果想保持原逻辑需要在配置项用配置 at_sender=false
