### PR TITLE
根据新版api重写部分代码,支持配置其他api

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ip 负载均衡或者自己做ip池（大概…<br>
 |     chat_memory_max     | 否  | int           |         10         |                          设置会话记忆上下文数量，填入大于2的数字                           |
 |       history_max       | 否  | int           |        100         |                        设置保存的最大历史聊天记录长度，填入大于2的数字                         |
 |    history_save_path    | 否  | str           | "data/ChatHistory" |                               设置会话记录保存路径                                |
-|     openai_api_base     | 否  | str           |        None        |                                  反向代理                                   |
+|     openai_api_base     | 否  | str           |https://api.openai.com/v1|                          其他api地址/反向代理                                   |
 |   key_load_balancing    | 否  | bool          |       false        |           是否启用apikey负载均衡，即每次使用不同的key访问，默认为关，即一直使用一个key直到失效再切换           |
 |       temperature       | 否  | float         |        0.5         | 设置使用gpt的理智值(temperature)，介于0~2之间，较高值如`0.8`会使会话更加随机，较低值如`0.2`会使会话更加集中和确定 |
 |       preset_path       | 否  | str           |   "data/Presets"   |                              填入自定义预设文件夹路径                               |
@@ -161,7 +161,7 @@ openai_proxy="x.x.x.x:xxxxx"
 chat_memory_max=10 # 填入大于2的数字
 history_max=100 # 填入大于2的数字
 history_save_path="E:/Kawaii" # 填入你的历史会话保存文件夹路径，如果修改最好填绝对路径，不过一般不需要修改，可以直接删掉这一行
-openai_api_base = "" # cf workers，空字符串或留空都将不使用
+openai_api_base = "https://api.moonshot.cn/v1" # 其他api地址(需支持openai库) 如kimi / cloudflare workers，空字符串或留空都将不使用
 timeout=10
 preset_path="E:/Kitty" # 填入你的历史会话保存文件夹路径，如果修改最好填绝对路径，不过一般不需要修改，可以直接删掉这一行
 allow_private=true # 是否允许私聊触发插件

--- a/__init__.py
+++ b/__init__.py
@@ -75,6 +75,7 @@ __plugin_meta__ = PluginMetadata(
 
 allow_private: bool = plugin_config.allow_private
 api_keys: APIKeyPool = session_container.api_keys
+base_url: str = session_container.base_url
 temperature: float = plugin_config.temperature
 model: str = plugin_config.model_name
 max_tokens: int = plugin_config.max_tokens
@@ -319,7 +320,7 @@ async def _(event: MessageEvent, info: Dict[str, Any] = RegexDict()):
             await Chat.send(f"自动创建并加入会话 '{session.name}' 成功", at_sender=True)
     else:
         session: Session = group_usage[user_id]
-    answer: str = await session.ask_with_content(api_keys, content, 'user', temperature, model, max_tokens)
+    answer: str = await session.ask_with_content(api_keys, base_url ,content, 'user', temperature, model, max_tokens)
     await Chat.finish(answer, at_sender=at_sender)
 
 

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ class Config(BaseModel, extra=Extra.ignore, arbitrary_types_allowed=True):
     history_save_path: Path = Path("data/ChatHistory").absolute()
     preset_path: Path = Path("data/Presets").absolute()
     openai_proxy: str = None
-    openai_api_base: str = None
+    openai_api_base: str = "https://api.openai.com/v1"
     chat_memory_max: int = 10
     history_max: int = 100
     temperature: float = 0.5

--- a/sessions.py
+++ b/sessions.py
@@ -227,13 +227,13 @@ class Session:
             if not api_key.status:
                 logger.warning(f'{log_info} 被标记失效，已跳过... \n失效原因:{api_key.fail_res}')
                 continue
-            client = OpenAI(
+            aclient = OpenAI(
                 api_key=api_key.key,
                 base_url="https://api.moonshot.cn/v1",
             )
             logger.debug(f'当前使用 {log_info}')
-            try:
-                completion: dict = await client.chat.completions.create(
+            try: 
+                completion: dict = await aclient.chat.completions.create(
                     model=model,
                     messages=self.chat_memory,
                     temperature=temperature,

--- a/sessions.py
+++ b/sessions.py
@@ -7,7 +7,7 @@ from typing import List, Dict, Optional, Union, Set
 import openai
 from nonebot.log import logger
 from nonebot.adapters.onebot.v11 import MessageEvent, GroupMessageEvent
-from openai import OpenAI, APIResponseValidationError, AuthenticationError, RateLimitError
+from openai import AsyncOpenAI, APIResponseValidationError, AuthenticationError, RateLimitError
 
 from .config import plugin_config
 from .apikey import APIKeyPool, APIKey
@@ -227,7 +227,7 @@ class Session:
             if not api_key.status:
                 logger.warning(f'{log_info} 被标记失效，已跳过... \n失效原因:{api_key.fail_res}')
                 continue
-            aclient = OpenAI(
+            aclient = AsyncOpenAI(
                 api_key=api_key.key,
                 base_url="https://api.moonshot.cn/v1",
             )

--- a/sessions.py
+++ b/sessions.py
@@ -23,6 +23,7 @@ if proxy:
     proxy_client = httpx.AsyncClient(proxies=proxy)
     logger.info("已配置代理")
 else:
+    proxy_client = None
     logger.warning("未配置代理")
 
 def get_group_id(event: MessageEvent) -> str:

--- a/sessions.py
+++ b/sessions.py
@@ -24,7 +24,7 @@ if proxy:
     logger.critical("由于openai库发生变化, 请使用全局代理")
 
 if plugin_config.openai_api_base:
-    openai.api_base = plugin_config.openai_api_base
+    openai.base_url = plugin_config.openai_api_base
 
 
 def get_group_id(event: MessageEvent) -> str:

--- a/sessions.py
+++ b/sessions.py
@@ -23,7 +23,7 @@ if proxy:
     proxy_client = httpx.AsyncClient(proxies=proxy)
     logger.info("已配置代理")
 else:
-    proxy_client = None
+    proxy_client = httpx.AsyncClient()
     logger.warning("未配置代理")
 
 def get_group_id(event: MessageEvent) -> str:


### PR DESCRIPTION
# 根据新版api重写部分代码,支持openai v1.12
# 支持配置其他api -> 填写config中 `openai_base_url`

## eg. 使用kimi
### `openai_api_base="https://api.moonshot.cn/v1"` 
### `model_name="moonshot-v1-8k"`